### PR TITLE
Update documentation for job telemetry

### DIFF
--- a/lib/oban/telemetry.ex
+++ b/lib/oban/telemetry.ex
@@ -25,6 +25,10 @@ defmodule Oban.Telemetry do
   * `[:oban, :job, :stop]` — after a job succeeds and the success is recorded in the database
   * `[:oban, :job, :exception]` — after a job fails and the failure is recorded in the database
 
+  Jobs that complete with `:ok`, `:cancelled`, `:snoozed`, and `:discard` count as 
+  suceeded and emit the `:stop` event. Jobs that complete with an `:error` or raised an exception
+  emit the `:exception` event.
+
   All job events share the same details about the job that was executed. In addition, failed jobs
   provide the error type, the error itself, and the stacktrace. The following chart shows which
   metadata you can expect for each event:


### PR DESCRIPTION
The changes elaborate on what counts as success in the context of job telemetry. 

Maybe my wording here is off, but essentially it would be nice to point out that not only jobs that return `ok` count as successful ones. I think that currently it might be difficult to figure out from the first glance purely by reading documentation.

It's also possible to circumvent this whole description of success by replacing `succeeded` with `finished` and providing the list of values corresponding to events.